### PR TITLE
Nw enh/13 14/create form

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -1,0 +1,3 @@
+html {
+    scroll-behavior: smooth;
+}

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -6,6 +6,7 @@ import { ApplicationProvider } from './application/ApplicationProvider';
 import { CompanyDetails } from './company/CompanyDetails';
 import { CompanyListView } from './company/CompanyListView';
 import { CompanyProvider } from './company/CompanyProvider';
+import { CreateForm } from './createForm/CreateForm';
 import { JobDetails } from './job/JobDetails';
 import { JobListView } from './job/JobListView';
 import { JobProvider } from './job/JobProvider';
@@ -41,6 +42,14 @@ export const ApplicationViews = () => (
         <ApplicationListView />
       </Route>
     </ApplicationProvider>
+
+    <CompanyProvider>
+      <JobProvider>
+        <Route exact path="/create">
+          <CreateForm />
+        </Route>
+      </JobProvider>
+    </CompanyProvider>
 
   </>
 );

--- a/src/components/application/ApplicationListView.js
+++ b/src/components/application/ApplicationListView.js
@@ -12,20 +12,20 @@ export const ApplicationListView = (props) => {
   }, []);
 
   return (
-    <>
+    <div className="min-h-(screen-16) bg-gray-100">
       {/* Table is shown on larger screens */}
       {/* < div className="hidden container mx-auto mt-16 lg:block" > */}
-      < div className="container mx-auto mt-16 block" >
+      < div className="container mx-auto block" >
         <div className="flex justify-center">
           <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div className="py-2 align-middle inline-block max-w-screen-lg sm:px-6 lg:px-8">
-              <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+              <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg mt-16">
                 {applicationList && <ApplicationListTable applicationList={applicationList} />}
               </div>
             </div>
           </div>
         </div>
       </div >
-    </>
+    </div>
   );
 };

--- a/src/components/company/CompanyListView.js
+++ b/src/components/company/CompanyListView.js
@@ -14,13 +14,13 @@ export const CompanyListView = (props) => {
 
   if (companyList.length > 0) {
     return (
-      <>
+      <div className="min-h-(screen-16) bg-gray-100">
         {/* Table is shown on larger screens */}
-        <div className="hidden container mx-auto mt-16 lg:block">
+        <div className="hidden container mx-auto lg:block">
           <div className="flex justify-center">
             <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
               <div className="py-2 align-middle inline-block max-w-screen-lg sm:px-6 lg:px-8">
-                <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg mt-16">
                   {companyList && <CompanyListTable companyList={companyList} />}
                 </div>
               </div>
@@ -28,12 +28,14 @@ export const CompanyListView = (props) => {
           </div>
         </div>
         {/* Cards are shown on smaller screens (tablets or smaller) */}
-        <div className="block container mx-auto mt-16 lg:hidden">
-          <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-            {companyList && companyList.map((company) => <CompanyListCard key={company.id} company={company} />)}
-          </ul>
+        <div className="block container mx-auto lg:hidden">
+          <div className="flex justify-center">
+            <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 mt-16">
+              {companyList && companyList.map((company) => <CompanyListCard key={company.id} company={company} />)}
+            </ul>
+          </div>
         </div>
-      </>
+      </div>
     );
   }
   // Don't render anything unless we have at least 1 Company in our list

--- a/src/components/company/CompanyProvider.js
+++ b/src/components/company/CompanyProvider.js
@@ -16,8 +16,20 @@ export const CompanyProvider = (props) => {
       .then(setCompanyList);
   };
 
+  // Create a new compnay
+  const createCompany = (newCompanyDetails) => (
+    fetch('http://localhost:8000/companies', {
+      method: 'POST',
+      headers: {
+        Authorization: `Token ${localStorage.getItem('apptrakz_token')}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(newCompanyDetails),
+    })
+  );
+
   return (
-    <CompanyContext.Provider value={{ companyList, getCompanies }} >
+    <CompanyContext.Provider value={{ companyList, createCompany, getCompanies }} >
       { props.children}
     </CompanyContext.Provider>
   );

--- a/src/components/createForm/CreateForm.js
+++ b/src/components/createForm/CreateForm.js
@@ -46,56 +46,68 @@ export const CreateForm = (props) => {
 
   const submitCompany = (e) => {
     e.preventDefault();
-    console.error('Submission Completed');
+
+    // TODO: Create POST submission for company
+    console.error('Company Submission Completed');
+
+    // After submitting, make sure we call the `getCompanies` function again
+    // to update our select list for the job section
+    getCompanies();
+  };
+
+  const submitJob = (e) => {
+    e.preventDefault();
+
+    console.error('Job Submission Completed');
   };
 
   return (
     <div className="min-h-(screen-16) bg-gray-100">
       <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div class="mt-10 sm:mt-0">
-          <div class="md:grid md:grid-cols-3 md:gap-6">
-            <div class="md:col-span-1">
-              <div class="px-4 sm:px-0">
-                <h3 class="text-lg font-medium leading-6 text-gray-900">Company Information</h3>
-                <p class="mt-1 text-sm text-gray-600">
+        <div className="mt-10 sm:mt-0">
+          <div className="md:grid md:grid-cols-3 md:gap-6">
+            <div className="md:col-span-1">
+              <div className="px-4 sm:px-0">
+                <h3 className="text-lg font-medium leading-6 text-gray-900">Company Information</h3>
+                <p className="mt-1 text-sm text-gray-600">
                   Fill out the company's information here.
                 </p>
               </div>
             </div>
-            <div class="mt-5 md:mt-0 md:col-span-2">
+            <div className="mt-5 md:mt-0 md:col-span-2">
               <form onSubmit={submitCompany}>
-                <div class="shadow overflow-hidden sm:rounded-md">
-                  <div class="px-4 py-5 bg-white sm:p-6">
-                    <div class="grid grid-cols-6 gap-6">
+                <div className="shadow overflow-hidden sm:rounded-md">
+                  <div className="px-4 py-5 bg-white sm:p-6">
+                    <div className="grid grid-cols-6 gap-6">
 
-                      <div class="col-span-6">
-                        <label for="name" class="block text-sm font-medium text-gray-700">Company Name*</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="name" id="name" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.name} required />
+                      <div className="col-span-6">
+                        <label htmlFor="name" className="block text-sm font-medium text-gray-700">Company Name*</label>
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="name" id="name" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.name} required />
                       </div>
 
-                      <div class="col-span-6">
-                        <label for="website" class="block text-sm font-medium text-gray-700">Company Website*</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="website" id="website" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.website} required />
+                      <div className="col-span-6">
+                        <label htmlFor="website" className="block text-sm font-medium text-gray-700">Company Website*</label>
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="website" id="website" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.website} required />
                       </div>
 
-                      <div class="col-span-6">
-                        <label for="address1" class="block text-sm font-medium text-gray-700">Street address*</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="address1" id="address1" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.address1} required />
+                      <div className="col-span-6">
+                        <label htmlFor="address1" className="block text-sm font-medium text-gray-700">Street address*</label>
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="address1" id="address1" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.address1} required />
                       </div>
 
-                      <div class="col-span-6">
-                        <label for="address2" class="block text-sm font-medium text-gray-700">Suite, Unit, Apt, etc.</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="address2" id="address2" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.address2} />
+                      <div className="col-span-6">
+                        <label htmlFor="address2" className="block text-sm font-medium text-gray-700">Suite, Unit, Apt, etc.</label>
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="address2" id="address2" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.address2} />
                       </div>
 
-                      <div class="col-span-6 sm:col-span-6 lg:col-span-2">
-                        <label for="city" class="block text-sm font-medium text-gray-700">City*</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="city" id="city" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.city} required />
+                      <div className="col-span-6 sm:col-span-6 lg:col-span-2">
+                        <label htmlFor="city" className="block text-sm font-medium text-gray-700">City*</label>
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="city" id="city" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.city} required />
                       </div>
 
-                      <div class="col-span-6 sm:col-span-2">
-                        <label for="state" class="block text-sm font-medium text-gray-700">State*</label>
-                        <select onChange={handleControlledInputChangeCompany} id="state" name="state" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" value={currentCompany.state || ''} required>
+                      <div className="col-span-6 sm:col-span-2">
+                        <label htmlFor="state" className="block text-sm font-medium text-gray-700">State*</label>
+                        <select onChange={handleControlledInputChangeCompany} id="state" name="state" className="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" value={currentCompany.state || ''} required>
                           <option value="" disabled>Select a State...</option>
                           <option value="AL" >Alabama</option>
                           <option value="AK">Alaska</option>
@@ -151,9 +163,9 @@ export const CreateForm = (props) => {
                         </select>
                       </div>
 
-                      <div class="col-span-6 sm:col-span-3 lg:col-span-2">
-                        <label for="zipcode" class="block text-sm font-medium text-gray-700">ZIP / Postal*</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="zipcode" id="zipcode" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.zipcode} required />
+                      <div className="col-span-6 sm:col-span-3 lg:col-span-2">
+                        <label htmlFor="zipcode" className="block text-sm font-medium text-gray-700">ZIP / Postal*</label>
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="zipcode" id="zipcode" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.zipcode} required />
                       </div>
                     </div>
                   </div>
@@ -163,8 +175,8 @@ export const CreateForm = (props) => {
                         * denotes required field
                       </small>
                     </div>
-                    <div class="px-4 py-3 text-right sm:px-6">
-                      <button type="submit" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                    <div className="px-4 py-3 text-right sm:px-6">
+                      <button type="submit" className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                         Save
                     </button>
                     </div>
@@ -175,45 +187,47 @@ export const CreateForm = (props) => {
           </div>
         </div>
 
-        <div class="hidden sm:block" aria-hidden="true">
-          <div class="py-5">
-            <div class="border-t border-gray-200"></div>
+        <div className="hidden sm:block" aria-hidden="true">
+          <div className="py-5">
+            <div className="border-t border-gray-200"></div>
           </div>
         </div>
 
-        <div class="mt-10 sm:mt-0">
-          <div class="md:grid md:grid-cols-3 md:gap-6">
-            <div class="md:col-span-1">
-              <div class="px-4 sm:px-0">
-                <h3 class="text-lg font-medium leading-6 text-gray-900">Job Information</h3>
-                <p class="mt-1 text-sm text-gray-600">
+        <div className="mt-10 sm:mt-0">
+          <div className="md:grid md:grid-cols-3 md:gap-6">
+            <div className="md:col-span-1">
+              <div className="px-4 sm:px-0">
+                <h3 className="text-lg font-medium leading-6 text-gray-900">Job Information</h3>
+                <p className="mt-1 text-sm text-gray-600">
                   Fill out the Job's information here.
                 </p>
               </div>
             </div>
-            <div class="mt-5 md:mt-0 md:col-span-2">
-              <form>
-                <div class="shadow overflow-hidden sm:rounded-md">
-                  <div class="px-4 py-5 bg-white sm:p-6">
-                    <div class="grid grid-cols-6 gap-6">
+            <div className="mt-5 md:mt-0 md:col-span-2">
+              <form onSubmit={submitJob}>
+                <div className="shadow overflow-hidden sm:rounded-md">
+                  <div className="px-4 py-5 bg-white sm:p-6">
+                    <div className="grid grid-cols-6 gap-6">
 
-                      <div class="col-span-6">
-                        <label for="role_title" class="block text-sm font-medium text-gray-700">Role Title*</label>
-                        <input type="text" name="role_title" id="role_title" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                      <div className="col-span-6">
+                        <label htmlFor="role_title" className="block text-sm font-medium text-gray-700">Role Title*</label>
+                        <input onChange={handleControlledInputChangeJob} type="text" name="role_title" id="role_title" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
                       </div>
 
-                      <div class="col-span-6 sm:col-span-3">
-                        <label for="company" class="block text-sm font-medium text-gray-700">Company*</label>
-                        <select id="company" name="company" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" required>
-                          <option>First Company</option>
-                          <option>Second Company</option>
-                          <option>Third Company</option>
+                      <div className="col-span-6 sm:col-span-3">
+                        <label htmlFor="company" className="block text-sm font-medium text-gray-700">Company*</label>
+                        <select onChange={handleControlledInputChangeJob} id="company" name="company" className="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" value={currentJob.company || ''} required>
+                          <option value="" disabled>Select a Company...</option>
+                          {companyList.map((company) => (
+                            <option key={company.id} value={company.id}>{company.name}</option>
+                          ))}
                         </select>
                       </div>
 
-                      <div class="col-span-6 sm:col-span-3">
-                        <label for="type" class="block text-sm font-medium text-gray-700">Job Type*</label>
-                        <select id="type" name="type" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" required>
+                      <div className="col-span-6 sm:col-span-3">
+                        <label htmlFor="type" className="block text-sm font-medium text-gray-700">Job Type*</label>
+                        <select onChange={handleControlledInputChangeJob} id="type" name="type" className="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" value={currentJob.type || ''} required>
+                          <option value="" disabled>Select a Job Type...</option>
                           <option>Full-Time</option>
                           <option>Part-Time</option>
                           <option>Contract</option>
@@ -221,24 +235,24 @@ export const CreateForm = (props) => {
                         </select>
                       </div>
 
-                      <div class="col-span-6 sm:col-span-3">
-                        <label for="salary" class="block text-sm font-medium text-gray-700">Salary Expectation</label>
-                        <input type="text" name="email_address" id="email_address" autocomplete="email" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                      <div className="col-span-6 sm:col-span-3">
+                        <label htmlFor="salary" className="block text-sm font-medium text-gray-700">Salary Expectation</label>
+                        <input onChange={handleControlledInputChangeJob} type="text" name="salary" id="salary" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
                       </div>
 
-                      <div class="col-span-6">
-                        <label for="qualifications" class="block text-sm font-medium text-gray-700">Important Qualifications*</label>
-                        <input type="text" name="qualifications" id="qualifications" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                      <div className="col-span-6">
+                        <label htmlFor="qualifications" className="block text-sm font-medium text-gray-700">Important Qualifications*</label>
+                        <input onChange={handleControlledInputChangeJob} type="text" name="qualifications" id="qualifications" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
                       </div>
 
-                      <div class="col-span-6">
-                        <label for="post_link" class="block text-sm font-medium text-gray-700">Job Posting Link*</label>
-                        <input type="text" name="post_link" id="post_link" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                      <div className="col-span-6">
+                        <label htmlFor="post_link" className="block text-sm font-medium text-gray-700">Job Posting Link*</label>
+                        <input onChange={handleControlledInputChangeJob} type="text" name="post_link" id="post_link" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
                       </div>
 
-                      <div class="col-span-6">
-                        <label for="description" class="block text-sm font-medium text-gray-700">Job Description* <small>(supports linebreaks)</small></label>
-                        <textarea name="description" id="descripton" rows="25" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm-text-sm border-gray-300 rounded-md whitespace-pre-wrap"></textarea>
+                      <div className="col-span-6">
+                        <label htmlFor="description" className="block text-sm font-medium text-gray-700">Job Description* <small>(supports linebreaks)</small></label>
+                        <textarea onChange={handleControlledInputChangeJob} name="description" id="descripton" rows="25" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm-text-sm border-gray-300 rounded-md whitespace-pre-wrap"></textarea>
                       </div>
                     </div>
                   </div>
@@ -248,8 +262,8 @@ export const CreateForm = (props) => {
                         * denotes required field
                       </small>
                     </div>
-                    <div class="px-4 py-3 text-right sm:px-6">
-                      <button onClick={() => { }} type="button" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                    <div className="px-4 py-3 text-right sm:px-6">
+                      <button type="submit" className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                         Save
                     </button>
                     </div>

--- a/src/components/createForm/CreateForm.js
+++ b/src/components/createForm/CreateForm.js
@@ -47,8 +47,11 @@ export const CreateForm = (props) => {
   const submitCompany = (e) => {
     e.preventDefault();
 
+    const newCompanyDetails = currentCompany;
+
     // TODO: Create POST submission for company
     console.error('Company Submission Completed');
+    console.error(JSON.stringify(newCompanyDetails));
 
     // After submitting, make sure we call the `getCompanies` function again
     // to update our select list for the job section
@@ -58,7 +61,11 @@ export const CreateForm = (props) => {
   const submitJob = (e) => {
     e.preventDefault();
 
+    const newJobDetails = currentJob;
+    newJobDetails.company = parseInt(currentJob.company, 10);
+
     console.error('Job Submission Completed');
+    console.error(JSON.stringify(newJobDetails));
   };
 
   return (

--- a/src/components/createForm/CreateForm.js
+++ b/src/components/createForm/CreateForm.js
@@ -1,0 +1,164 @@
+/* eslint-disable max-len */
+import React from 'react';
+
+export const CreateForm = (props) => {
+  const val = 1;
+
+  return (
+    <div className="min-h-(screen-16) bg-gray-100">
+      <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div class="mt-10 sm:mt-0">
+          <div class="md:grid md:grid-cols-3 md:gap-6">
+            <div class="md:col-span-1">
+              <div class="px-4 sm:px-0">
+                <h3 class="text-lg font-medium leading-6 text-gray-900">Company Information</h3>
+                <p class="mt-1 text-sm text-gray-600">
+                  Fill out the company's information here.
+                </p>
+              </div>
+            </div>
+            <div class="mt-5 md:mt-0 md:col-span-2">
+              {/* <form action="#" method="POST"> */}
+              <form>
+                <div class="shadow overflow-hidden sm:rounded-md">
+                  <div class="px-4 py-5 bg-white sm:p-6">
+                    <div class="grid grid-cols-6 gap-6">
+
+                      <div class="col-span-6">
+                        <label for="name" class="block text-sm font-medium text-gray-700">Company Name*</label>
+                        <input type="text" name="name" id="name" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                      </div>
+
+                      <div class="col-span-6">
+                        <label for="address1" class="block text-sm font-medium text-gray-700">Street address*</label>
+                        <input type="text" name="address1" id="address1" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                      </div>
+
+                      <div class="col-span-6">
+                        <label for="address2" class="block text-sm font-medium text-gray-700">Suite, Unit, Apt, etc.</label>
+                        <input type="text" name="address2" id="address2" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                      </div>
+
+                      <div class="col-span-6 sm:col-span-6 lg:col-span-2">
+                        <label for="city" class="block text-sm font-medium text-gray-700">City*</label>
+                        <input type="text" name="city" id="city" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                      </div>
+
+                      <div class="col-span-6 sm:col-span-3 lg:col-span-2">
+                        <label for="state" class="block text-sm font-medium text-gray-700">State*</label>
+                        <input type="text" name="state" id="state" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                      </div>
+
+                      <div class="col-span-6 sm:col-span-3 lg:col-span-2">
+                        <label for="zipcode" class="block text-sm font-medium text-gray-700">ZIP / Postal*</label>
+                        <input type="text" name="zipcode" id="zipcode" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex justify-between">
+                    <div className="ml-4 my-auto text-gray-600">
+                      <small>
+                        * denotes required field
+                      </small>
+                    </div>
+                    <div class="px-4 py-3 text-right sm:px-6">
+                      <button onClick={() => { }} type="submit" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                        Save
+                    </button>
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+
+        <div class="hidden sm:block" aria-hidden="true">
+          <div class="py-5">
+            <div class="border-t border-gray-200"></div>
+          </div>
+        </div>
+
+        <div class="mt-10 sm:mt-0">
+          <div class="md:grid md:grid-cols-3 md:gap-6">
+            <div class="md:col-span-1">
+              <div class="px-4 sm:px-0">
+                <h3 class="text-lg font-medium leading-6 text-gray-900">Job Information</h3>
+                <p class="mt-1 text-sm text-gray-600">
+                  Fill out the Job's information here.
+                </p>
+              </div>
+            </div>
+            <div class="mt-5 md:mt-0 md:col-span-2">
+              {/* <form action="#" method="POST"> */}
+              <form>
+                <div class="shadow overflow-hidden sm:rounded-md">
+                  <div class="px-4 py-5 bg-white sm:p-6">
+                    <div class="grid grid-cols-6 gap-6">
+
+                      <div class="col-span-6">
+                        <label for="role_title" class="block text-sm font-medium text-gray-700">Role Title*</label>
+                        <input type="text" name="role_title" id="role_title" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                      </div>
+
+                      <div class="col-span-6 sm:col-span-3">
+                        <label for="company" class="block text-sm font-medium text-gray-700">Company*</label>
+                        <select id="company" name="company" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" required>
+                          <option>First Company</option>
+                          <option>Second Company</option>
+                          <option>Third Company</option>
+                        </select>
+                      </div>
+
+                      <div class="col-span-6 sm:col-span-3">
+                        <label for="type" class="block text-sm font-medium text-gray-700">Job Type*</label>
+                        <select id="type" name="type" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" required>
+                          <option>Full-Time</option>
+                          <option>Part-Time</option>
+                          <option>Contract</option>
+                          <option>Other</option>
+                        </select>
+                      </div>
+
+                      <div class="col-span-6 sm:col-span-3">
+                        <label for="salary" class="block text-sm font-medium text-gray-700">Salary Expectation</label>
+                        <input type="text" name="email_address" id="email_address" autocomplete="email" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                      </div>
+
+                      <div class="col-span-6">
+                        <label for="qualifications" class="block text-sm font-medium text-gray-700">Important Qualifications*</label>
+                        <input type="text" name="qualifications" id="qualifications" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                      </div>
+
+                      <div class="col-span-6">
+                        <label for="post_link" class="block text-sm font-medium text-gray-700">Job Posting Link*</label>
+                        <input type="text" name="post_link" id="post_link" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                      </div>
+
+                      <div class="col-span-6">
+                        <label for="description" class="block text-sm font-medium text-gray-700">Job Description* <small>(supports linebreaks)</small></label>
+                        <textarea name="description" id="descripton" rows="25" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm-text-sm border-gray-300 rounded-md whitespace-pre-wrap"></textarea>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex justify-between">
+                    <div className="ml-4 my-auto text-gray-600">
+                      <small>
+                        * denotes required field
+                      </small>
+                    </div>
+                    <div class="px-4 py-3 text-right sm:px-6">
+                      <button onClick={() => { }} type="submit" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                        Save
+                    </button>
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/createForm/CreateForm.js
+++ b/src/components/createForm/CreateForm.js
@@ -1,8 +1,53 @@
 /* eslint-disable max-len */
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
+import { CompanyContext } from '../company/CompanyProvider';
+import { JobContext } from '../job/JobProvider';
 
 export const CreateForm = (props) => {
-  const val = 1;
+  const { companyList, getCompanies } = useContext(CompanyContext);
+  const { jobList } = useContext(JobContext);
+
+  const [currentCompany, setCurrentCompany] = useState({
+    name: '',
+    address1: '',
+    address2: '',
+    city: '',
+    state: '',
+    zipcode: '',
+    website: '',
+  });
+
+  const [currentJob, setCurrentJob] = useState({
+    role_title: '',
+    type: '',
+    qualifications: '',
+    post_link: '',
+    salary: '',
+    description: '',
+    company: '',
+  });
+
+  useEffect(() => {
+    getCompanies();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleControlledInputChangeCompany = (event) => {
+    const newCompanyState = { ...currentCompany };
+    newCompanyState[event.target.name] = event.target.value;
+    setCurrentCompany(newCompanyState);
+  };
+
+  const handleControlledInputChangeJob = (event) => {
+    const newJobState = { ...currentJob };
+    newJobState[event.target.name] = event.target.value;
+    setCurrentJob(newJobState);
+  };
+
+  const submitCompany = (e) => {
+    e.preventDefault();
+    console.error('Submission Completed');
+  };
 
   return (
     <div className="min-h-(screen-16) bg-gray-100">
@@ -18,40 +63,97 @@ export const CreateForm = (props) => {
               </div>
             </div>
             <div class="mt-5 md:mt-0 md:col-span-2">
-              {/* <form action="#" method="POST"> */}
-              <form>
+              <form onSubmit={submitCompany}>
                 <div class="shadow overflow-hidden sm:rounded-md">
                   <div class="px-4 py-5 bg-white sm:p-6">
                     <div class="grid grid-cols-6 gap-6">
 
                       <div class="col-span-6">
                         <label for="name" class="block text-sm font-medium text-gray-700">Company Name*</label>
-                        <input type="text" name="name" id="name" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="name" id="name" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.name} required />
+                      </div>
+
+                      <div class="col-span-6">
+                        <label for="website" class="block text-sm font-medium text-gray-700">Company Website*</label>
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="website" id="website" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.website} required />
                       </div>
 
                       <div class="col-span-6">
                         <label for="address1" class="block text-sm font-medium text-gray-700">Street address*</label>
-                        <input type="text" name="address1" id="address1" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="address1" id="address1" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.address1} required />
                       </div>
 
                       <div class="col-span-6">
                         <label for="address2" class="block text-sm font-medium text-gray-700">Suite, Unit, Apt, etc.</label>
-                        <input type="text" name="address2" id="address2" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="address2" id="address2" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.address2} />
                       </div>
 
                       <div class="col-span-6 sm:col-span-6 lg:col-span-2">
                         <label for="city" class="block text-sm font-medium text-gray-700">City*</label>
-                        <input type="text" name="city" id="city" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="city" id="city" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.city} required />
                       </div>
 
-                      <div class="col-span-6 sm:col-span-3 lg:col-span-2">
+                      <div class="col-span-6 sm:col-span-2">
                         <label for="state" class="block text-sm font-medium text-gray-700">State*</label>
-                        <input type="text" name="state" id="state" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                        <select onChange={handleControlledInputChangeCompany} id="state" name="state" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" value={currentCompany.state || ''} required>
+                          <option value="" disabled>Select a State...</option>
+                          <option value="AL" >Alabama</option>
+                          <option value="AK">Alaska</option>
+                          <option value="AZ">Arizona</option>
+                          <option value="AR">Arkansas</option>
+                          <option value="CA">California</option>
+                          <option value="CO">Colorado</option>
+                          <option value="CT">Connecticut</option>
+                          <option value="DE">Delaware</option>
+                          <option value="DC">District Of Columbia</option>
+                          <option value="FL">Florida</option>
+                          <option value="GA">Georgia</option>
+                          <option value="HI">Hawaii</option>
+                          <option value="ID">Idaho</option>
+                          <option value="IL">Illinois</option>
+                          <option value="IN">Indiana</option>
+                          <option value="IA">Iowa</option>
+                          <option value="KS">Kansas</option>
+                          <option value="KY">Kentucky</option>
+                          <option value="LA">Louisiana</option>
+                          <option value="ME">Maine</option>
+                          <option value="MD">Maryland</option>
+                          <option value="MA">Massachusetts</option>
+                          <option value="MI">Michigan</option>
+                          <option value="MN">Minnesota</option>
+                          <option value="MS">Mississippi</option>
+                          <option value="MO">Missouri</option>
+                          <option value="MT">Montana</option>
+                          <option value="NE">Nebraska</option>
+                          <option value="NV">Nevada</option>
+                          <option value="NH">New Hampshire</option>
+                          <option value="NJ">New Jersey</option>
+                          <option value="NM">New Mexico</option>
+                          <option value="NY">New York</option>
+                          <option value="NC">North Carolina</option>
+                          <option value="ND">North Dakota</option>
+                          <option value="OH">Ohio</option>
+                          <option value="OK">Oklahoma</option>
+                          <option value="OR">Oregon</option>
+                          <option value="PA">Pennsylvania</option>
+                          <option value="RI">Rhode Island</option>
+                          <option value="SC">South Carolina</option>
+                          <option value="SD">South Dakota</option>
+                          <option value="TN">Tennessee</option>
+                          <option value="TX">Texas</option>
+                          <option value="UT">Utah</option>
+                          <option value="VT">Vermont</option>
+                          <option value="VA">Virginia</option>
+                          <option value="WA">Washington</option>
+                          <option value="WV">West Virginia</option>
+                          <option value="WI">Wisconsin</option>
+                          <option value="WY">Wyoming</option>
+                        </select>
                       </div>
 
                       <div class="col-span-6 sm:col-span-3 lg:col-span-2">
                         <label for="zipcode" class="block text-sm font-medium text-gray-700">ZIP / Postal*</label>
-                        <input type="text" name="zipcode" id="zipcode" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" required />
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="zipcode" id="zipcode" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.zipcode} required />
                       </div>
                     </div>
                   </div>
@@ -62,7 +164,7 @@ export const CreateForm = (props) => {
                       </small>
                     </div>
                     <div class="px-4 py-3 text-right sm:px-6">
-                      <button onClick={() => { }} type="submit" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                      <button type="submit" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                         Save
                     </button>
                     </div>
@@ -90,7 +192,6 @@ export const CreateForm = (props) => {
               </div>
             </div>
             <div class="mt-5 md:mt-0 md:col-span-2">
-              {/* <form action="#" method="POST"> */}
               <form>
                 <div class="shadow overflow-hidden sm:rounded-md">
                   <div class="px-4 py-5 bg-white sm:p-6">
@@ -148,7 +249,7 @@ export const CreateForm = (props) => {
                       </small>
                     </div>
                     <div class="px-4 py-3 text-right sm:px-6">
-                      <button onClick={() => { }} type="submit" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                      <button onClick={() => { }} type="button" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                         Save
                     </button>
                     </div>

--- a/src/components/createForm/CreateForm.js
+++ b/src/components/createForm/CreateForm.js
@@ -1,11 +1,13 @@
 /* eslint-disable max-len */
 import React, { useContext, useEffect, useState } from 'react';
 import { CompanyContext } from '../company/CompanyProvider';
-import { JobContext } from '../job/JobProvider';
+// import { JobContext } from '../job/JobProvider';
 
 export const CreateForm = (props) => {
-  const { companyList, getCompanies } = useContext(CompanyContext);
-  const { jobList } = useContext(JobContext);
+  const { companyList, createCompany, getCompanies } = useContext(CompanyContext);
+  // const { } = useContext(JobContext);
+
+  const [companySubmissionErrors, setCompanySubmissionErrors] = useState([]);
 
   const [currentCompany, setCurrentCompany] = useState({
     name: '',
@@ -46,16 +48,41 @@ export const CreateForm = (props) => {
 
   const submitCompany = (e) => {
     e.preventDefault();
+    setCompanySubmissionErrors([]);
 
-    const newCompanyDetails = currentCompany;
+    // const result = createCompany(currentCompany);
+    createCompany(currentCompany)
+      .then((res) => {
+        if (res.ok) {
+          // If response was OK, then we reset the form
+          setCurrentCompany(
+            {
+              name: '',
+              address1: '',
+              address2: '',
+              city: '',
+              state: '',
+              zipcode: '',
+              website: '',
+            },
+          );
 
-    // TODO: Create POST submission for company
-    console.error('Company Submission Completed');
-    console.error(JSON.stringify(newCompanyDetails));
-
-    // After submitting, make sure we call the `getCompanies` function again
-    // to update our select list for the job section
-    getCompanies();
+          // Grab the updated companies list so the job section below updates with the new company
+          getCompanies();
+        } else {
+          throw res;
+        }
+      })
+      .catch((err) => {
+        err.json().then((jsonError) => {
+          const errors = [];
+          // eslint-disable-next-line guard-for-in
+          for (const key in jsonError) {
+            errors.push({ field: key, error: jsonError[key][0][0] });
+          }
+          setCompanySubmissionErrors(errors);
+        });
+      });
   };
 
   const submitJob = (e) => {
@@ -89,27 +116,27 @@ export const CreateForm = (props) => {
 
                       <div className="col-span-6">
                         <label htmlFor="name" className="block text-sm font-medium text-gray-700">Company Name*</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="name" id="name" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.name} required />
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="name" id="name" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" value={currentCompany.name} required />
                       </div>
 
                       <div className="col-span-6">
                         <label htmlFor="website" className="block text-sm font-medium text-gray-700">Company Website*</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="website" id="website" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.website} required />
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="website" id="website" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" value={currentCompany.website} required />
                       </div>
 
                       <div className="col-span-6">
                         <label htmlFor="address1" className="block text-sm font-medium text-gray-700">Street address*</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="address1" id="address1" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.address1} required />
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="address1" id="address1" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" value={currentCompany.address1} required />
                       </div>
 
                       <div className="col-span-6">
                         <label htmlFor="address2" className="block text-sm font-medium text-gray-700">Suite, Unit, Apt, etc.</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="address2" id="address2" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.address2} />
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="address2" id="address2" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" value={currentCompany.address2} />
                       </div>
 
                       <div className="col-span-6 sm:col-span-6 lg:col-span-2">
                         <label htmlFor="city" className="block text-sm font-medium text-gray-700">City*</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="city" id="city" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.city} required />
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="city" id="city" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" value={currentCompany.city} required />
                       </div>
 
                       <div className="col-span-6 sm:col-span-2">
@@ -172,7 +199,7 @@ export const CreateForm = (props) => {
 
                       <div className="col-span-6 sm:col-span-3 lg:col-span-2">
                         <label htmlFor="zipcode" className="block text-sm font-medium text-gray-700">ZIP / Postal*</label>
-                        <input onChange={handleControlledInputChangeCompany} type="text" name="zipcode" id="zipcode" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" defaultValue={currentCompany.zipcode} required />
+                        <input onChange={handleControlledInputChangeCompany} type="text" name="zipcode" id="zipcode" className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" value={currentCompany.zipcode} required />
                       </div>
                     </div>
                   </div>
@@ -188,6 +215,32 @@ export const CreateForm = (props) => {
                     </button>
                     </div>
                   </div>
+                  {companySubmissionErrors.length > 0 ? (
+                    <div class="rounded-md bg-red-50 p-4">
+                      <div class="flex">
+                        <div class="flex-shrink-0">
+                          {/* <!-- Heroicon name: solid/x-circle --> */}
+                          <svg class="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+                          </svg>
+                        </div>
+                        <div class="ml-3">
+                          <h3 class="text-sm font-medium text-red-800">
+                            There were {companySubmissionErrors.length} errors with your submission
+                          </h3>
+                          <div class="mt-2 text-sm text-red-700">
+                            <ul class="list-disc pl-5 space-y-1">
+                              {companySubmissionErrors && companySubmissionErrors.map((error) => (
+                                <li>
+                                  {error.field}: {error.error}
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ) : ''}
                 </div>
               </form>
             </div>

--- a/src/components/job/JobListView.js
+++ b/src/components/job/JobListView.js
@@ -13,13 +13,13 @@ export const JobListView = (props) => {
   }, []);
 
   return (
-    <>
+    <div className="min-h-(screen-16) bg-gray-100">
       {/* Table is shown on larger screens */}
-      <div className="hidden container mx-auto mt-16 lg:block">
+      <div className="hidden container mx-auto lg:block">
         <div className="flex justify-center">
           <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div className="py-2 align-middle inline-block max-w-screen-lg sm:px-6 lg:px-8">
-              <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+              <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg mt-16">
                 {jobList && <JobListTable jobList={jobList} />}
               </div>
             </div>
@@ -27,11 +27,13 @@ export const JobListView = (props) => {
         </div>
       </div>
       {/* Cards are shown on smaller screens (tablets or smaller) */}
-      <div className="block container mx-auto mt-16 lg:hidden">
-        <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-          {jobList && jobList.map((job) => <JobListCard key={job.id} job={job} />)}
-        </ul>
+      <div className="block container mx-auto lg:hidden">
+        <div className="flex justify-center">
+          <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 mt-16">
+            {jobList && jobList.map((job) => <JobListCard key={job.id} job={job} />)}
+          </ul>
+        </div>
       </div>
-    </>
+    </div>
   );
 };

--- a/src/components/job/JobProvider.js
+++ b/src/components/job/JobProvider.js
@@ -16,8 +16,20 @@ export const JobProvider = (props) => {
       .then(setJobList);
   };
 
+  // Create a new job
+  const createJob = (newJobDetails) => (
+    fetch('http://localhost:8000/jobs', {
+      method: 'POST',
+      headers: {
+        Authorization: `Token ${localStorage.getItem('apptrakz_token')}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(newJobDetails),
+    })
+  );
+
   return (
-    <JobContext.Provider value={{ getJobs, jobList }}>
+    <JobContext.Provider value={{ createJob, getJobs, jobList }}>
       { props.children}
     </JobContext.Provider>
   );

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -75,12 +75,12 @@ export const NavBar = (props) => {
           {(localStorage.getItem('apptrakz_token') !== null) ? (
             <div className="flex items-center">
               <div className="flex-shrink-0">
-                <Link to="/jobs/new" className="relative inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                <Link to="/create" className="relative inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                   {/* <!-- Heroicon name: plus --> */}
                   <svg className="-ml-1 mr-2 h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                     <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
                   </svg>
-                  <span>New Job</span>
+                  <span>New...</span>
                 </Link>
               </div>
               <div className="hidden md:ml-4 md:flex-shrink-0 md:flex md:items-center">


### PR DESCRIPTION
This PR creates the `/create` page which is the endpoint for the Company and Job creation forms.  Also updated some styling on the companies/jobs/applications pages to match the format of the create page.  

Additionally, I returned the fetch promise to the `CreateForm` page where I called them so that I could process error messages and show them.  Those will now show up just below the `Save` buttons after the user submits data which is invalid and they will contain a reference to the incorrect field as well as the error message.  Example shown below of when a user enters `www.google.com` as the website instead of `https://www.google.com` (for example).  The count is also dynamic in the event there were multiple errors returned.

![image](https://user-images.githubusercontent.com/10491407/110416895-1a349e00-805a-11eb-8ed4-3fa166f058bb.png)

Closes #13 
Closes #14