### PR TITLE
Nw/hotfix/redundant get applications call

### DIFF
--- a/src/components/application/ApplicationListView.js
+++ b/src/components/application/ApplicationListView.js
@@ -5,7 +5,6 @@ import { ApplicationListTable } from './ApplicationListTable';
 export const ApplicationListView = (props) => (
   <div className="min-h-(screen-16) bg-gray-100">
     {/* Table is shown on larger screens */}
-    {/* < div className="hidden container mx-auto mt-16 lg:block" > */}
     < div className="container mx-auto block" >
       <div className="flex justify-center">
         <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">

--- a/src/components/application/ApplicationListView.js
+++ b/src/components/application/ApplicationListView.js
@@ -1,31 +1,21 @@
 /* eslint-disable max-len */
-import React, { useContext, useEffect } from 'react';
-import { ApplicationContext } from './ApplicationProvider';
+import React from 'react';
 import { ApplicationListTable } from './ApplicationListTable';
 
-export const ApplicationListView = (props) => {
-  const { applicationList, getApplications } = useContext(ApplicationContext);
-
-  useEffect(() => {
-    getApplications();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  return (
-    <div className="min-h-(screen-16) bg-gray-100">
-      {/* Table is shown on larger screens */}
-      {/* < div className="hidden container mx-auto mt-16 lg:block" > */}
-      < div className="container mx-auto block" >
-        <div className="flex justify-center">
-          <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-            <div className="py-2 align-middle inline-block max-w-screen-lg sm:px-6 lg:px-8">
-              <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg mt-16">
-                {applicationList && <ApplicationListTable />}
-              </div>
+export const ApplicationListView = (props) => (
+  <div className="min-h-(screen-16) bg-gray-100">
+    {/* Table is shown on larger screens */}
+    {/* < div className="hidden container mx-auto mt-16 lg:block" > */}
+    < div className="container mx-auto block" >
+      <div className="flex justify-center">
+        <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div className="py-2 align-middle inline-block max-w-screen-lg sm:px-6 lg:px-8">
+            <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg mt-16">
+              <ApplicationListTable />
             </div>
           </div>
         </div>
-      </div >
-    </div>
-  );
-};
+      </div>
+    </div >
+  </div>
+);

--- a/src/components/application/ApplicationProvider.js
+++ b/src/components/application/ApplicationProvider.js
@@ -26,7 +26,7 @@ export const ApplicationProvider = (props) => {
       },
       body: JSON.stringify(applicationDetails),
     })
-      .then(getApplications())
+      .then(() => getApplications())
   );
 
   // Update an application


### PR DESCRIPTION
Found a redundant call to `getApplications()` in the `ApplicationListView`.  Removed that and I am no longer seeing the duplicate call in the network tab of dev tools.